### PR TITLE
Support URL format for OTLP endpoint configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -48,6 +49,19 @@ type OtelConfig struct {
 	serviceName string
 }
 
+// parseOTLPEndpoint parses an OTLP endpoint string that may be a URL (http://host:port)
+// or just host:port. Returns the host:port and whether the connection should use TLS.
+func parseOTLPEndpoint(rawEndpoint string) (endpoint string, useTLS bool, err error) {
+	if strings.Contains(rawEndpoint, "://") {
+		u, err := url.Parse(rawEndpoint)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to parse OTLP endpoint URL: %w", err)
+		}
+		return u.Host, u.Scheme == "https", nil
+	}
+	return rawEndpoint, false, nil
+}
+
 func setupTracerProvider(ctx context.Context, config *OtelConfig) (func(context.Context) error, error) {
 	if config.endpoint == "" {
 		slog.Info("OpenTelemetry tracing disabled", "reason", "no endpoint configured")
@@ -56,11 +70,19 @@ func setupTracerProvider(ctx context.Context, config *OtelConfig) (func(context.
 
 	slog.Info("Setting up OpenTelemetry tracing", "endpoint", config.endpoint, "service", config.serviceName)
 
+	endpoint, useTLS, err := parseOTLPEndpoint(config.endpoint)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create OTLP HTTP exporter
-	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpoint(config.endpoint),
-		otlptracehttp.WithInsecure(), // Use WithTLSClientConfig() for production
-	)
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpoint),
+	}
+	if !useTLS {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseOTLPEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		endpoint string
+		useTLS   bool
+		wantErr  bool
+	}{
+		{
+			name:     "host:port only",
+			input:    "localhost:4318",
+			endpoint: "localhost:4318",
+			useTLS:   false,
+		},
+		{
+			name:     "http URL",
+			input:    "http://localhost:4318",
+			endpoint: "localhost:4318",
+			useTLS:   false,
+		},
+		{
+			name:     "https URL",
+			input:    "https://otel-collector.example.com:4318",
+			endpoint: "otel-collector.example.com:4318",
+			useTLS:   true,
+		},
+		{
+			name:     "http URL without port",
+			input:    "http://localhost",
+			endpoint: "localhost",
+			useTLS:   false,
+		},
+		{
+			name:     "https URL without port",
+			input:    "https://otel-collector.example.com",
+			endpoint: "otel-collector.example.com",
+			useTLS:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, useTLS, err := parseOTLPEndpoint(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseOTLPEndpoint(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if endpoint != tt.endpoint {
+				t.Errorf("parseOTLPEndpoint(%q) endpoint = %q, want %q", tt.input, endpoint, tt.endpoint)
+			}
+			if useTLS != tt.useTLS {
+				t.Errorf("parseOTLPEndpoint(%q) useTLS = %v, want %v", tt.input, useTLS, tt.useTLS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- OTLP endpoint setting (`-otel-endpoint` / `OTEL_EXPORTER_OTLP_ENDPOINT`) now accepts URL format (`http://host:port`, `https://host:port`) in addition to plain `host:port`
- Automatically enables TLS when `https://` scheme is used
- Fixes "invalid URL escape" error when using `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`

## Test plan
- [ ] `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` works without error
- [ ] `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318` still works (backward compatible)
- [ ] `OTEL_EXPORTER_OTLP_ENDPOINT=https://...` uses TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)