### PR TITLE
Propagate incoming W3C traceparent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ $ printenv
 
 Each HTTP request generates a trace with span name "printenv", including HTTP method, path, status code, and latency timing.
 
+Incoming requests carrying a W3C `traceparent` header are joined to the upstream trace: the request span is created as a child of the caller's span, preserving the same `trace_id`. Requests without a `traceparent` header start a new trace.
+
 When tracing is enabled, access logs include `trace_id` field for correlating logs with traces.
 
 ## LICENSE

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -154,6 +155,14 @@ func setupTracerProvider(ctx context.Context, config *OtelConfig) (func(context.
 	)
 
 	otel.SetTracerProvider(tp)
+
+	// Set W3C Trace Context propagator so that an incoming traceparent header
+	// is extracted and the request span is joined to the upstream trace.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
 	slog.Info("OpenTelemetry tracing enabled")
 
 	return tp.Shutdown, nil

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -128,4 +132,46 @@ func TestAccessLogMiddleware(t *testing.T) {
 			t.Errorf("trace_id = %v, want 0af7651916cd43dd8448eb211c80319c", logEntry["trace_id"])
 		}
 	})
+}
+
+func TestTraceparentPropagation(t *testing.T) {
+	// Configure the W3C Trace Context propagator, as setupTracerProvider does
+	// when tracing is enabled.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	const (
+		wantTraceID = "0af7651916cd43dd8448eb211c80319c"
+		parentSpan  = "b7ad6b7169203331"
+	)
+
+	var gotTraceID, gotSpanID string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// otelhttp starts a new child span, so the trace ID is inherited from
+		// the incoming traceparent while the span ID is freshly generated.
+		sc := trace.SpanContextFromContext(r.Context())
+		gotTraceID = sc.TraceID().String()
+		gotSpanID = sc.SpanID().String()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Use a real SDK tracer provider so otelhttp starts a genuine child span
+	// (the default noop tracer would pass the parent span context through unchanged).
+	tp := sdktrace.NewTracerProvider()
+	defer tp.Shutdown(context.Background())
+	handler := otelhttp.NewHandler(inner, "printenv", otelhttp.WithTracerProvider(tp))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("traceparent", "00-"+wantTraceID+"-"+parentSpan+"-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotTraceID != wantTraceID {
+		t.Errorf("trace_id = %q, want %q (incoming traceparent not propagated)", gotTraceID, wantTraceID)
+	}
+	if gotSpanID == "" || gotSpanID == parentSpan {
+		t.Errorf("span_id = %q, want a new child span id (not empty, not the parent %q)", gotSpanID, parentSpan)
+	}
 }


### PR DESCRIPTION
## What

Set the global OpenTelemetry `TextMapPropagator` (TraceContext + Baggage) when tracing is enabled, so `otelhttp` extracts an incoming `traceparent` header and creates the request span as a child of the upstream trace.

## Why

Previously no propagator was configured, so the global default was a no-op. Even when a caller sent a `traceparent` header, it was ignored and every request started a brand-new root trace (new `trace_id`), breaking distributed trace continuity.

With this change, requests carrying a `traceparent` inherit the caller's `trace_id`; requests without one still start a new trace as before.